### PR TITLE
Update to 1.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,11 @@ repositories {
     }
 }
 
-dependencies {
-    compile 'com.destroystokyo.paper:paper-api:1.16.5-R0.1-SNAPSHOT'
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
+dependencies {
+    compileOnly 'io.papermc.paper:paper-api:1.17.1-R0.1-SNAPSHOT'
 }
 
 test {

--- a/src/main/java/io/egg/tickspeed/TickTimeJob.java
+++ b/src/main/java/io/egg/tickspeed/TickTimeJob.java
@@ -50,12 +50,6 @@ public class TickTimeJob implements Runnable {
         }
     }
     public Class<?> getNmsClass(String name) throws ClassNotFoundException {
-        // explode the Server interface implementation's package name into its components
-        String[] array = Bukkit.getServer().getClass().getPackage().getName().split("\\.");
-
-        // pick out the component representing the package version if it's present
-        String packageVersion = array.length == 4 ? array[3] + "." : "";
-
         // construct the qualified class name from the obtained package version
         String qualName = "net.minecraft." + name;
 

--- a/src/main/java/io/egg/tickspeed/TickTimeJob.java
+++ b/src/main/java/io/egg/tickspeed/TickTimeJob.java
@@ -1,6 +1,5 @@
 package io.egg.tickspeed;
 
-
 import org.bukkit.Bukkit;
 
 import java.lang.reflect.Field;
@@ -18,9 +17,9 @@ public class TickTimeJob implements Runnable {
         try {
             utils = getNmsClass("SystemUtils");
             getMillis = utils.getDeclaredMethod("getMonotonicMillis");
-            server = getNmsClass("MinecraftServer");
+            server = getNmsClass("server.MinecraftServer");
             getServer = server.getMethod("getServer");
-            f = server.getDeclaredField("nextTick");
+            f = server.getDeclaredField("ao");
         } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException e) {
             e.printStackTrace();
         }
@@ -58,7 +57,7 @@ public class TickTimeJob implements Runnable {
         String packageVersion = array.length == 4 ? array[3] + "." : "";
 
         // construct the qualified class name from the obtained package version
-        String qualName = "net.minecraft.server." + packageVersion + name;
+        String qualName = "net.minecraft." + name;
 
         // simple call to get the Class object
         return Class.forName(qualName);


### PR DESCRIPTION
Update this plugin to work with Minecraft 1.17.1

Changes:
- Changed Paper API version from 1.16.5 to 1.17.1 in build.gradle
- Fixed qualified name generation to work with 1.17.1
- Changed `nextTick` to `ao` (note: I found that this worked via trial-by-error)